### PR TITLE
Using latest available TLS

### DIFF
--- a/Client/Client.php
+++ b/Client/Client.php
@@ -251,6 +251,7 @@ class Client
         $curl = curl_init();
         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false);
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($curl, CURLOPT_SSLVERSION, CURL_SSLVERSION_TLSv1); // Latest TLS(1.x)
         curl_setopt_array($curl, $this->curlOptions);
         curl_setopt($curl, CURLOPT_URL, $request->getUri());
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
Paypal are migrating there API endpoints to a minimum of TLS 1.2 with the sandbox having already been migrated and live endpoints due in June.

Specify TLS 1 as a minimum version. Note that there is a separate constant for TLS 1.x, specifying TLSv1 will use the highest supported TLS version.
