### PR TITLE
refactor: use capture status instead of authorisation status to evaluate payment status

### DIFF
--- a/Plugin/ExpressCheckoutPlugin.php
+++ b/Plugin/ExpressCheckoutPlugin.php
@@ -245,7 +245,7 @@ class ExpressCheckoutPlugin extends AbstractPlugin
         $this->throwUnlessSuccessResponse($details, $transaction);
 
 
-        switch ($details->body->get('PAYMENTSTATUS')) {
+        switch ($response->body->get('PAYMENTSTATUS')) {
             case 'Completed':
                 break;
 


### PR DESCRIPTION
It makes more sense to use the payment capture status instead of the authorization status to determine the general payment status.
